### PR TITLE
fix(home): small typos on index page

### DIFF
--- a/_jade/en/index.jade
+++ b/_jade/en/index.jade
@@ -18,7 +18,7 @@ block content
                 .home-brand-panel.description.container
                     .home-info
                         .home-brand Apache ECharts
-                        .home-subtitle An Open Source JavaScript Visualiztion Library
+                        .home-subtitle An Open Source JavaScript Visualization Library
                         .home-btn-panel
                             a.btn.btn-main.btn-index-home(href='#{host}/en/tutorial.html#Get%20Started%20with%20ECharts%20in%205%20minutes')
                                 include ../components/svg/index-learn
@@ -61,7 +61,7 @@ block content
                                     .index-feature-icon#icon-3
                                 .index-feature-right
                                     h3.reveal Professional Data Analysis
-                                    p.reveal-later Manage data through datasets, which support data transform like filtering, clustering, and regression to help analyze multi-dimensional analysis of the same data.
+                                    p.reveal-later Manage data through datasets, which support data transforms like filtering, clustering, and regression to help analyze multi-dimensional analysis of the same data.
                         .col-md-6
                             .index-feature#index-feature-4
                                 .index-feature-left.reveal


### PR DESCRIPTION
The subtitle on the index page mentions 'Visualiztion', which should be 'Visualization'. Also fix a small grammar issue in some of the body text.