### PR TITLE
fix: typos on docs and comments

### DIFF
--- a/_jade/components/download.jade
+++ b/_jade/components/download.jade
@@ -37,8 +37,8 @@ block content
                         li 从镜像网站下载 apache-echarts-X.Y.Z-src.zip
                         li 从 <a href="https://www.apache.org/dist/echarts/">Apache</a> 下载 checksum apache-echarts-X.Y.Z-src.zip.asc
                         li 下载 <a href="https://www.apache.org/dist/echarts/KEYS">ECharts KEYS</a>
-                        li gpg –import KEYS
-                        li gpg –verify apache-echarts-X.Y.Z-src.zip.asc
+                        li gpg --import KEYS
+                        li gpg --verify apache-echarts-X.Y.Z-src.zip.asc
 
                     h4 使用 SHA-512 验证
                     ol

--- a/_jade/en/download.jade
+++ b/_jade/en/download.jade
@@ -49,8 +49,8 @@ block content
                         li Download the release apache-echarts-X.Y.Z-src.zip from a mirror site.
                         li Download the checksum apache-echarts-X.Y.Z-src.zip.asc from <a href="https://www.apache.org/dist/echarts/">Apache</a>.
                         li Download the <a href="https://www.apache.org/dist/echarts/KEYS">ECharts KEYS</a> file.
-                        li gpg –import KEYS
-                        li gpg –verify apache-echarts-X.Y.Z-src.zip.asc
+                        li gpg --import KEYS
+                        li gpg --verify apache-echarts-X.Y.Z-src.zip.asc
 
                     h4 To perform a quick check using SHA-512:
                     ol

--- a/_jade/en/faq.jade
+++ b/_jade/en/faq.jade
@@ -105,7 +105,7 @@ block content
 
                 h2#event Event processing
                 h3 How do I get events such as chart clicks?
-                p Pelease read <a href="https://echarts.apache.org/handbook/en/concepts/event">official tutorial</a>. The types of events supported by ECharts can be found in the <a href="https://echarts.apache.org/en/api.html#events">related API</a>.
+                p Read the <a href="https://echarts.apache.org/handbook/en/concepts/event">official tutorial</a>. The types of events supported by ECharts can be found in the <a href="https://echarts.apache.org/en/api.html#events">related API</a>.
 
 
 
@@ -121,4 +121,3 @@ block content
 block extra_js
     script(type='text/javascript').
         document.getElementById('nav-doc').className = 'active';
-

--- a/builder/lib/transform-dev-bundle.js
+++ b/builder/lib/transform-dev-bundle.js
@@ -57020,7 +57020,7 @@ function BasicSourceMapConsumer(aSourceMap) {
 
   // Pass `true` below to allow duplicate names and sources. While source maps
   // are intended to be compressed and deduplicated, the TypeScript compiler
-  // sometimes generates source maps with duplicates in them. See Github issue
+  // sometimes generates source maps with duplicates in them. See GitHub issue
   // #72 and bugzil.la/889492.
   this._names = ArraySet.fromArray(names.map(String), true);
   this._sources = ArraySet.fromArray(sources, true);

--- a/js/config.js
+++ b/js/config.js
@@ -485,11 +485,11 @@ var EXAMPLES = [
         type: 'scatter'
     },  {
         id: 'scatter-polar-punchCard',
-        title: 'Punch Card of Github',
+        title: 'Punch Card of GitHub',
         type: 'scatter'
     },  {
         id: 'scatter-punchCard',
-        title: 'Punch Card of Github',
+        title: 'Punch Card of GitHub',
         type: 'scatter'
     },  {
         id: 'scatter-single-axis',

--- a/slides/asset/tools/getStarHistory.js
+++ b/slides/asset/tools/getStarHistory.js
@@ -73,7 +73,7 @@ async function getStarHistory(repo) {
   const getArray = sampleUrls.map(url => axiosGit.get(url));
 
   const resArray = await Promise.all(getArray).catch(res => {
-    throw 'Github api limit exceeded, Try in the new hour!'
+    throw 'GitHub api limit exceeded, Try in the new hour!'
   });
 
   const starHistory = pageIndexes.map((p, i) => {


### PR DESCRIPTION
Was just checking out the website and wanted to suggest a few small changes.

* Github → GitHub (GitHub is a proper noun, capitalization should be preserved.)
* `–` should be `--` for CLI args, I'm guessing a formatter of some kind changed it up.
* "Pelease" would be written as "Please", regardless I actually removed the word because these are instructions, not requests.
* Minor formatting changes for consistency I guess, not sure what's changing and why. 🤔 I'm guessing if there was an EditorConfig file configured with the projects conventions that wouldn't have happened, looks like line endings changed?