### PR TITLE
Update English release announce to 5.5

### DIFF
--- a/_jade/en/index.jade
+++ b/_jade/en/index.jade
@@ -41,7 +41,7 @@ block content
                             #home-landing-animation-close-btn
                                 include ../components/svg/close.svg
 
-            section#new-version-section 📣 Apache ECharts 5.4 is out! See <a href='#{host}/handbook/#{ecWWWLang}/basics/release-note/5-4-0?ref=banner' target='_blank'>what's new</a>
+            section#new-version-section 📣 Apache ECharts 5.5 is out! See <a href='#{host}/handbook/#{ecWWWLang}/basics/release-note/5-5-0?ref=banner' target='_blank'>what's new</a>
 
             //- section#events-section
             //-     .container


### PR DESCRIPTION
### Issue

In the current English version of Apache ECharts website at https://echarts.apache.org/en/index.html, we can see the following message:

> 📣 Apache ECharts 5.4 is out! See [what's new](https://echarts.apache.org/handbook/en/basics/release-note/5-4-0?ref=banner)

In the Chinese version at https://echarts.apache.org/zh/index.html, the same message mentions a more recent version; the latest one:

> 📣 Apache ECharts 5.5 发布了! 查看[新特性](https://echarts.apache.org/handbook/zh/basics/release-note/5-5-0?ref=banner)

This was updated via https://github.com/apache/echarts-www/commit/5db5386ca5854e5218f717cacd5a8e2028624911

### Description

This PR suggests updating the corresponding English message in order to mention the latest 5.5 version of Apache ECharts, and redirect to the latest release note.

_Note: Given the fact that the issue was rather straightforward, I haven't created an issue in the repository first. Feel free to close this PR if it wasn't the right way to suggest this change :)_