### PR TITLE
fix: examples do not display correctly in the documentation

### DIFF
--- a/_jade/layouts/example-simple.jade
+++ b/_jade/layouts/example-simple.jade
@@ -18,6 +18,8 @@ block extra_js
     script(src="#{cdn3rdRoot.vueJS}")
     script(src="#{cdn3rdRoot.elementUIJS}")
     script(src="#{getAssetUrl(cdnPayRoot, 'examples/js/example-bundle.js')}")
+    script(type="text/javascript").
+        window.EC_WWW_CDN_PAY_ROOT = '#{cdnPayRoot}';
 
     block global_args_extra
 


### PR DESCRIPTION
Look at https://echarts.apache.org/zh/option.html#title, that examples is not display.