### PR TITLE
Hint at the llms.txt Markdown docs for clients that do not run JavaScript

### DIFF
--- a/_jade/layouts/doc.jade
+++ b/_jade/layouts/doc.jade
@@ -9,8 +9,18 @@ block extra_head
         }
     link(rel="stylesheet", href="#{cdn3rdRoot.elementUICSS}")
     link(rel="stylesheet", href="#{getAssetUrl(cdnPayRoot, ecWWWLang + '/css/doc-bundle.css')}")
+    link(rel="describedby", href="llms.txt")
 
 block content
+
+    //- Points agents that fetch the raw HTML to the Markdown docs (llms.txt).
+    //- Hidden via .sr-only, not display:none, so HTML-to-text tools keep it.
+    blockquote.sr-only(aria-hidden="true")
+        | Documentation Index
+        br
+        | Fetch the complete documentation index at: https://echarts.apache.org/#{ecWWWLang}/llms.txt
+        br
+        | Use this file to discover the available Markdown documentation before exploring further.
 
     nav(class='navbar navbar-default navbar-fixed-top doc-nav' id="ec-doc-nav")
         if ecWWWLang == 'en'


### PR DESCRIPTION
## Summary

Follow-up to apache/echarts-doc#497. Makes `llms.txt` and the Markdown docs discoverable from the doc pages for clients that fetch the raw HTML (AI coding agents), which otherwise only get the SPA shell.

Changes in `_jade/layouts/doc.jade` only (option, option-gl, api, tutorial, en and zh):

- `<blockquote class="sr-only" aria-hidden="true">` at the top of the page content (before the nav), pointing to `https://echarts.apache.org/{lang}/llms.txt`. Same pattern as the [Cloudflare docs](https://developers.cloudflare.com/workers/) and the [Anthropic docs](https://code.claude.com/docs/en/overview); matches the proposed [Agent-Friendly Documentation Spec](https://agentdocsspec.com/spec/#llms-txt-directive-html).
- `<link rel="describedby" href="llms.txt">` in the head, as recommended by [llmstxt.org](https://llmstxt.org/).

Not visible in a browser, with or without JavaScript.

Scoped to the doc pages: they are what the current `llms.txt` covers, and when an agent was asked configuration questions and told to answer from primary sources rather than memory (given no URL, or only the site root), the first page it fetched on the site was `option.html` every time. If wider coverage matters more, moving the blockquote to `basic.jade` would put it on every page.

## Why

Agents that fetch `option.html` get only the navigation shell and, in my tests, do not look for `/llms.txt` on their own. Instead they fall back to web search and the documentation source on GitHub, where the content is split across template partials and takes many fetches to piece together. With a pointer in the page, an agent given only the page URL went straight to `llms.txt` and the relevant Markdown file.

Placement matters because fetch tools pass different parts of the page to the model:

| Placement | Claude Code `WebFetch` | Codex `web.run open` |
|---|---|---|
| `<link>` in the head | dropped | dropped |
| `<noscript>` text | dropped | kept |
| Body text next to the nav (site banner) | kept | dropped as boilerplate |
| Hidden `<blockquote>` at the top of the page content (this PR) | kept | kept |

The last row was verified with both tools on the Cloudflare docs page, which uses the same pattern, and with Claude Code on the `en/option.html` generated by this PR.

- The `<link>` is kept anyway: it is what llmstxt.org recommends, costs one line, and works for tools that read link relations.
- The URL is written out in full because some tools only fetch URLs already present in the text (for example the [Claude API web fetch tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-fetch-tool#url-validation)). It points at echarts.apache.org rather than `config.host`, as the existing `#apache-banner` does.

## Testing

Built locally with `npm run sass` and `npm run jade`. The generated `en/option.html`, `zh/option.html`, and `en/api.html` contain the blockquote before the nav with the language-specific URL, and nothing is visible in a browser.
